### PR TITLE
Fix #23 - support for h5py>=3.0

### DIFF
--- a/rcca/__init__.py
+++ b/rcca/__init__.py
@@ -87,7 +87,7 @@ class _CCABase(object):
         h5.close()
 
     def load(self, filename):
-        h5 = h5py.File(filename, 'a')
+        h5 = h5py.File(filename, 'r')
         for key, value in h5.attrs.items():
             setattr(self, key, value)
         for di in range(len(h5.keys())):
@@ -95,7 +95,8 @@ class _CCABase(object):
             for key, value in h5[ds].items():
                 if di == 0:
                     setattr(self, key, [])
-                self.__getattribute__(key).append(value.value)
+                self.__getattribute__(key).append(value[()])
+        h5.close()
 
 
 class CCACrossValidate(_CCABase):


### PR DESCRIPTION
Support h5py>=3.0 by switching to the `[()]` syntax instead of `.value`.

I also changed the read mode of the file because even though it does not append anything to the file, it does changes the modification date of the file which is confusing.