### PR TITLE
FIX default number of components

### DIFF
--- a/rcca/rcca.py
+++ b/rcca/rcca.py
@@ -344,7 +344,7 @@ def kcca(
 
     nDs = len(kernel)
     nFs = [k.shape[0] for k in kernel]
-    numCC = min([k.shape[1] for k in kernel]) if numCC is None else numCC
+    numCC = min([k.shape[0] for k in kernel]) if numCC is None else numCC
 
     # Get the auto- and cross-covariance matrices
     crosscovs = [np.dot(ki, kj.T) for ki in kernel for kj in kernel]


### PR DESCRIPTION
Fixes #21 

In the default case `kernelcca=True`, it does not matter since the kernels are square.
However, when `kernelcca=False`, kernels are transposed from `data`, which is a list of arrays of shape (n_samples, n_features).
So the number of components should be min(n_features), and not min(n_samples).